### PR TITLE
Use walletconnect projectid, fix build on m3 mac

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build the react app
-FROM node:18-alpine AS node_build 
+FROM node:18 AS node_build 
 WORKDIR /var/www/app 
 COPY package.json ./
 RUN yarn
@@ -7,7 +7,7 @@ COPY . ./
 RUN yarn build
 
 # serve the app
-FROM nginx:1.23-alpine
+FROM nginx:1.23
 COPY --from=node_build /var/www/app/build /usr/share/nginx/html
 COPY nginx.config /etc/nginx/conf.d/default.conf
 EXPOSE 80

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,8 +18,12 @@ const { chains, provider } = configureChains(
   [publicProvider()]
 )
 
+// walletconnect projectId (this is a test id, please replace with real one!)
+const projectId = 'c4f79cc821944d9680842e34466bfb';
+
 const { connectors } = getDefaultWallets({
   appName: "Koinos Bridge",
+  projectId,
   chains,
 })
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,8 +18,8 @@ const { chains, provider } = configureChains(
   [publicProvider()]
 )
 
-// walletconnect projectId (this is a test id, please replace with real one!)
-const projectId = 'c4f79cc821944d9680842e34466bfb';
+// walletconnect projectId
+const projectId = 'c64ca949713c7b3ef89702e71583fb97';
 
 const { connectors } = getDefaultWallets({
   appName: "Koinos Bridge",


### PR DESCRIPTION
The alpine docker images have an issue with `gifsicle` on apple silicon even when building with `--platform linux/amd64`. This just uses the regular images instead.

Once built, the page would not load due to a console error of not specifying a walletconnect projectId. This adds our real walletconnect projectId.