### PR TITLE
Fix polling / waiting for signatures

### DIFF
--- a/src/pages/Redeem.jsx
+++ b/src/pages/Redeem.jsx
@@ -71,11 +71,8 @@ const Redeem = (props) => {
   );
 
   const hasEnoughSignatures = (recoverData) => {
-    return _get(recoverData, "signatures", []).length >= import.meta.env.VITE_NUMBER_OF_VALIDATORS || 2;
-  }
-
-  const hasAtLeastOneSignature = (recoverData) => {
-    return _get(recoverData, "signatures", []).length >= 1;
+    const requiredQuorum = import.meta.env.VITE_NUMBER_OF_VALIDATORS || 2;
+    return _get(recoverData, "signatures", []).length >= requiredQuorum;
   }
 
   // efects
@@ -280,11 +277,6 @@ const Redeem = (props) => {
         result = await bridge.getKoinTx(txIdParam ? txIdParam : sourceTX);
       }
     } catch (error) {
-      if (hasAtLeastOneSignature(result) && !hasEnoughSignatures(result)) { // these may come through as errors so they have to be handled here
-        let _timer = setTimeout(() => checkApi(txIdParam), 3000);
-        setChecker(_timer);
-        setRecover(result); // set recover to show the data while it's waiting for more signatures
-      }
       result = null;
       console.log(error);
       let _timer = setTimeout(() => checkApi(txIdParam), 3000);

--- a/src/pages/Redeem.jsx
+++ b/src/pages/Redeem.jsx
@@ -74,6 +74,10 @@ const Redeem = (props) => {
     return _get(recoverData, "signatures", []).length >= import.meta.env.VITE_NUMBER_OF_VALIDATORS || 2;
   }
 
+  const hasAtLeastOneSignature = (recoverData) => {
+    return _get(recoverData, "signatures", []).length >= 1;
+  }
+
   // efects
   useEffect(() => {
     if (searchParams.get("tx")) {
@@ -276,6 +280,11 @@ const Redeem = (props) => {
         result = await bridge.getKoinTx(txIdParam ? txIdParam : sourceTX);
       }
     } catch (error) {
+      if (hasAtLeastOneSignature(result) && !hasEnoughSignatures(result)) { // these may come through as errors so they have to be handled here
+        let _timer = setTimeout(() => checkApi(txIdParam), 3000);
+        setChecker(_timer);
+        setRecover(result); // set recover to show the data while it's waiting for more signatures
+      }
       result = null;
       console.log(error);
       let _timer = setTimeout(() => checkApi(txIdParam), 3000);


### PR DESCRIPTION
The `hasRequiredSignatures` function was always returning 2 if the environment variable was not set which means it was always returning true. This fixes that and solves the polling issue.