### PR TITLE
Add netlify toml for redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+  from = "/*"
+  to = "/"
+  status = 200


### PR DESCRIPTION
This solves a bug with netlify where react router doesn't work unless you navigate to `/`. The current behavior is that if you navigate directly to a path (like /bridge) or refresh the page, you get a 404 from netlify. This fix also makes it so our own 404 page renders instead for broken links which is also nice.

This is specific to netlify and doesn't effect anything else, it's just an added toml file and that's it