### PR TITLE
Add 3 minute try again message for transaction not found and update snackbar info color

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "kondor-js": "^1.1.0",
     "lodash": "^4.17.21",
     "moment": "^2.30.1",
-    "notistack": "^2.0.4",
+    "notistack": "^3.0.1",
     "react": "^18.0.0",
     "react-device-detect": "^2.2.2",
     "react-dom": "^18.0.0",

--- a/src/components/Layout/index.jsx
+++ b/src/components/Layout/index.jsx
@@ -1,6 +1,6 @@
-import { ThemeProvider, CssBaseline, Container, IconButton, useMediaQuery, useTheme, Box } from "@mui/material";
+import { ThemeProvider, CssBaseline, Container, IconButton, useMediaQuery, useTheme, Box, styled } from "@mui/material";
 import { createTheme, responsiveFontSizes } from "@mui/material/styles";
-import { SnackbarProvider } from "notistack";
+import { SnackbarProvider, MaterialDesignContent } from "notistack";
 import React, { useState, useEffect } from "react";
 import { Outlet } from "react-router-dom";
 
@@ -19,6 +19,7 @@ import Modals from "../Modals";
 // themes
 import lightThemeOptions from "../../theme/main-light";
 import darkThemeOptions from "../../theme/main-dark";
+
 
 const Layout = () => {
   // Load the theme setting from localStorage, default to false (light theme)
@@ -52,6 +53,16 @@ const Layout = () => {
     }
   }, []);
 
+  const StyledMaterialDesignContent = styled(MaterialDesignContent)(() => ({
+    '&.notistack-MuiContent-info': {
+      backgroundColor: theme.palette.primary.main,
+      color: "#fff !important",
+      '& *': {
+        color: "#fff !important",
+      },
+    },
+  }));
+
   return (
     <ThemeProvider theme={createTheme(theme)}>
       <CssBaseline />
@@ -60,6 +71,9 @@ const Layout = () => {
         anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
         autoHideDuration={15000}
         action={(key) => SnackbarActions(key)}
+        Components={{
+          info: StyledMaterialDesignContent,
+        }}
       >
         <Box sx={{ backgroundColor: theme.palette.background.main, position: 'relative' }}>
           <IconButton

--- a/src/pages/Redeem.jsx
+++ b/src/pages/Redeem.jsx
@@ -273,7 +273,8 @@ const Redeem = (props) => {
       Snackbar.enqueueSnackbar(
         <span>
           <Typography variant="h6">Transaction not found</Typography>
-          <Typography variant="body1" color="white">the transaction has not been found on the blockchain</Typography>
+          <Typography variant="body1" color="white">The transaction has not been found on the blockchain.</Typography>
+          <Typography variant="body1" color="white">Please wait up to 3 minutes and try again.</Typography>
         </span>,
         {
           variant: 'error',


### PR DESCRIPTION
This adds an extra message for people to try again in 3 minutes if the transaction is not found (this seems to be happening right now on sepolia rpc so this helps mitigate that).

Also resolves #37 