### PR TITLE
Only show 0 when there is a receivable asset

### DIFF
--- a/src/pages/Bridge.jsx
+++ b/src/pages/Bridge.jsx
@@ -177,13 +177,17 @@ const Bridge = () => {
     dispatch(setModal("SelectTokenToBridge"))
   }
 
-  const calculateReceiveAmount = (value) => {
-    // make sure value is a number
-    if (isNaN(value)) {
+  const calculateReceiveAmount = (value, receiveChainSymbol) => {
+    // if no receiving chain, return empty string instead of a 0
+    if(receiveChainSymbol === "..") {
       return "";
     }
+    // make sure value is a number
+    if (isNaN(value)) {
+      return 0;
+    }
     if(value <= 0) {
-      return "";
+      return 0;
     }
     // calculate receive amount
     // we will want to subtract the fee here depending on the type of token, market price, etc
@@ -705,7 +709,7 @@ const Bridge = () => {
           <Box sx={{ border: `1px solid ${theme.palette.background.light}`, borderRadius: "10px", padding: "10px 20px", display: "flex", alignContent: "center", flexDirection: "column" }} marginY={"1.4em"} display={"flex"} justifyContent={"space-between"}>
             <Box sx={{ display: "flex", justifyContent: "space-between", width: "100%", alignItems: "center" }}>
               <Typography variant="body1" component={"span"} sx={{ color: "text.grey2" }}>You will receive:</Typography>
-              <Typography variant="h6" component={"span"}>{calculateReceiveAmount(inputValue)} {findTokenSymbolForChain(tokenToBridge, toChain?.id)}</Typography>
+              <Typography variant="h6" component={"span"}>{calculateReceiveAmount(inputValue, findTokenSymbolForChain(tokenToBridge, toChain?.id))} {findTokenSymbolForChain(tokenToBridge, toChain?.id)}</Typography>
             </Box>
             <Box sx={{ display: "flex", justifyContent: "space-between", width: "100%", alignItems: "center" }}>
               <Typography variant="body1" component={"span"} sx={{ color: "text.grey2" }}>Receiving address:</Typography>


### PR DESCRIPTION
This makes it so the 0 next to the receiving asset is only there if there is actually a receiving asset, otherwise it is 0.

The previous PR made it so it was an empty string even if it was 0 which was probably wrong, this corrects that.