### PR TITLE
Fix glitchy behavior when typing input numbers while Sepolia is "from" network

### DIFF
--- a/src/components/Bridge/CustomConnectInfo/index.jsx
+++ b/src/components/Bridge/CustomConnectInfo/index.jsx
@@ -1,0 +1,65 @@
+import { get as _get } from "lodash";
+import { useDispatch, useSelector } from "react-redux";
+import { setModal } from "../../../redux/actions/modals";
+import { Button } from '@mui/material'
+import { CHAIN_IDS_TO_NAMES } from "./../../../constants/chains"
+// utils
+import { shortedAddress } from "./../../../utils/display";
+
+// the purpose of this is to not re-load the rainbowkit connection in re-renders
+// the CustomEthConnectButton causes re-rendering issues for this network status/connection because rainbowkit
+// this is just used to display the network status and the wallet address, not the connect button
+
+// props: walletAddress, optional actions
+
+const CustomConnectInfo = (props) => {
+  // Dispatch to call actions
+  const dispatch = useDispatch();
+
+  // selectors
+  const bridgeSelector = useSelector(state => state.bridge);
+  const settingsSelector = useSelector(state => state.settings);
+  // state
+  const chain = _get(bridgeSelector, "from", null);
+  const networkChain = _get(settingsSelector, "network", null);
+
+  return (
+    <div>
+      <div style={{ display: "flex", justifyContent: "space-between", marginBottom: "20px", gap: 12 }}>
+        <Button
+          style={{ display: "flex", alignItems: "center" }}
+          type="button"
+        >
+          {chain !== null ?
+            <div
+              style={{
+                background: chain.icon,
+                width: 12,
+                height: 12,
+                borderRadius: 999,
+                overflow: "hidden",
+                marginRight: 4,
+              }}
+            >
+              {chain.icon && (
+                <img
+                  alt={chain.name ?? "Chain icon"}
+                  src={chain.icon}
+                  style={{ width: 12, height: 12 }}
+                />
+              )}
+            </div>
+            : null}
+          {CHAIN_IDS_TO_NAMES[networkChain] ? CHAIN_IDS_TO_NAMES[networkChain] : CHAIN_IDS_TO_NAMES["UNSUPPORTED"]}
+        </Button>
+
+        <Button type="button" onClick={() => dispatch(setModal("Disconnect"))}>
+          {shortedAddress(props.walletAddress)}
+        </Button>
+      </div>
+      {props.actions}
+    </div>
+  )
+}
+
+export default CustomConnectInfo;

--- a/src/components/Bridge/CustomConnectInfo/index.jsx
+++ b/src/components/Bridge/CustomConnectInfo/index.jsx
@@ -50,7 +50,7 @@ const CustomConnectInfo = (props) => {
               )}
             </div>
             : null}
-          {CHAIN_IDS_TO_NAMES[networkChain] ? CHAIN_IDS_TO_NAMES[networkChain] : CHAIN_IDS_TO_NAMES["UNSUPPORTED"]}
+          {chain.name ? chain.name : CHAIN_IDS_TO_NAMES[networkChain] ? CHAIN_IDS_TO_NAMES[networkChain] : CHAIN_IDS_TO_NAMES["UNSUPPORTED"]}
         </Button>
 
         <Button type="button" onClick={() => dispatch(setModal("Disconnect"))}>

--- a/src/components/Bridge/CustomConnectInfo/index.jsx
+++ b/src/components/Bridge/CustomConnectInfo/index.jsx
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { setModal } from "../../../redux/actions/modals";
 import { Button } from '@mui/material'
 import { CHAIN_IDS_TO_NAMES } from "./../../../constants/chains"
+import { useAccountModal } from '@rainbow-me/rainbowkit';
 // utils
 import { shortedAddress } from "./../../../utils/display";
 
@@ -22,6 +23,9 @@ const CustomConnectInfo = (props) => {
   // state
   const chain = _get(bridgeSelector, "from", null);
   const networkChain = _get(settingsSelector, "network", null);
+
+  // for rainbowkit disconnect button
+  const { openAccountModal } = useAccountModal();
 
   return (
     <div>
@@ -53,7 +57,7 @@ const CustomConnectInfo = (props) => {
           {chain.name ? chain.name : CHAIN_IDS_TO_NAMES[networkChain] ? CHAIN_IDS_TO_NAMES[networkChain] : CHAIN_IDS_TO_NAMES["UNSUPPORTED"]}
         </Button>
 
-        <Button type="button" onClick={() => dispatch(setModal("Disconnect"))}>
+        <Button type="button" onClick={openAccountModal}>
           {shortedAddress(props.walletAddress)}
         </Button>
       </div>

--- a/src/pages/Bridge.jsx
+++ b/src/pages/Bridge.jsx
@@ -37,6 +37,7 @@ import SwapHorizIcon from '@mui/icons-material/SwapHoriz';
 // components
 import CustomEthConnectButton from "../components/Bridge/CustomEthConnectButton";
 import CustomKoinConnectButton from "../components/Bridge/CustomKoinConnectButton";
+import CustomConnectInfo from "../components/Bridge/CustomConnectInfo";
 import SelectChain from "../components/SelectChain";
 import { Rotate90DegreesCcw, TextRotateUp } from "@mui/icons-material";
 
@@ -85,7 +86,6 @@ const Bridge = () => {
       setLoadingBalance(false);
       return;
     };
-    setInputValue("0");
     let _bridge = BRIDGE_CHAINS.find(bridge => bridge.id == _get(fromChain, "id", null));
     let _network = _get(tokenToBridge, "networks", []).find(net => _get(net, 'chain', "") == _get(fromChain, "id", null));
     if (_get(fromChain, "chainType", "") == BRIDGE_CHAINS_TYPES.EVM && _get(account, 'isConnected', false)) {
@@ -415,7 +415,7 @@ const Bridge = () => {
 
   const BaseConnections = (props) => (
     <>
-      {_get(fromChain, "chainType", "") == BRIDGE_CHAINS_TYPES.EVM ? <CustomEthConnectButton {...props} /> : null}
+      {_get(fromChain, "chainType", "") == BRIDGE_CHAINS_TYPES.EVM ? <CustomConnectInfo walletAddress={account.address} {...props} /> : null}
       {_get(fromChain, "chainType", "") == BRIDGE_CHAINS_TYPES.KOIN ? <CustomKoinConnectButton {...props} /> : null}
     </>
   )


### PR DESCRIPTION
Resolves #50 - see description on that issue for instructions on how to reproduce.

The problem was that rainbowkit's connect button was glitching on every re-render. Every time you type a number into the input field, it caused a re-render and rainbowkit caused it to glitch out. This is why it was only happening with Sepolia as the "From" network and not Koin.

This fix uses a new `CustomConnectInfo` that works like the `CustomKoinConnectButton` without rainbowkit to display the network status and wallet address through `BaseConnections` effectively solving the issue.

Also resolves #49 - as far as I know, I don't think we need to reset the input field on balance checks so that line has been removed.